### PR TITLE
restrict semaphore

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -48,7 +48,7 @@ func TestGKEStockPrice(t *testing.T) {
 	cluster := gcloud.GKECluster{
 		Project:     "gke-stockprice",
 		ClusterName: "gke-stockprice-cluster-integration-test",
-		ComputeZone: "us-central1-a",
+		ComputeZone: "us-central1-f",
 		MachineType: "g1-small",
 		ExecCmd:     true, // 実際に作成削除を行う
 	}

--- a/movingavg.go
+++ b/movingavg.go
@@ -58,8 +58,8 @@ type CalculateMovingAvg struct {
 func (m CalculateMovingAvg) saveMovingAvgs(ctx context.Context, codes []string) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
-	//	sem := make(chan struct{}, m.calcConcurrency)
-	//	defer close(sem)
+	sem := make(chan struct{}, m.calcConcurrency)
+	defer close(sem)
 	for _, code := range codes {
 		code := code
 
@@ -68,10 +68,10 @@ func (m CalculateMovingAvg) saveMovingAvgs(ctx context.Context, codes []string) 
 			return ctx.Err()
 		default:
 		}
-		//sem <- struct{}{}
+		sem <- struct{}{}
 
 		eg.Go(func() error {
-			//	defer func() { <-sem }()
+			defer func() { <-sem }()
 			dm, err := m.movingAvgs(code)
 			if err != nil {
 				return fmt.Errorf("failed to calculateEachMovingAvg: %v", err)


### PR DESCRIPTION
以下のエラーが出たのに対応
```
2020/06/28 03:42:07 failed to execDailyProcess: failed to daily: failed to calcMovingAvg: failed to insert movingavg: failed to Exec: Error 1461: Can't create more than max_prepared_stmt_count statements (current value: 16382)
```

並行処理数を制限する