### PR TITLE
working_directoryのパスをホームディレクトリ以下に変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
             SHEET_CREDENTIAL=gke-stockprice-serviceaccount.json INTEGRATION_TEST_SHEETID=$INTEGRATION_TEST_SHEETID go test -v ./... -tags integration -run=TestGKEStockPrice -timeout 30m
 
   create_gke_cluster:
-    working_directory: /go/src/github.com/ludwig125/gke-stockprice
+    working_directory: ~/go/src/github.com/ludwig125 # この設定によって、stepsのcheckout時にworking_directory以下にgke-stockpriceリポジトリがgit cloneされる
     environment:
       PROJECT_NAME: gke-stockprice
       CLOUDSQL_INSTANCE: gke-stockprice-cloudsql-prod


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/ludwig125/gke-stockprice/236/workflows/d6feb9f7-89f0-4fb3-b9af-5f8782c37ebd/jobs/437

circleciのcheckout 時の、以下の `mkdir -p /go/src/github.com/ludwig125/gke-stockprice` の時に、「mkdir: can't create directory '/go/': Permission denied」と出てしまったのでカレントディレクトリにしてみる
```
# use git+ssh instead of https
git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
git config --global gc.auto 0 || true

if [ -e /go/src/github.com/ludwig125/gke-stockprice/.git ]
then
  cd /go/src/github.com/ludwig125/gke-stockprice
  git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
else
  mkdir -p /go/src/github.com/ludwig125/gke-stockprice
  cd /go/src/github.com/ludwig125/gke-stockprice
  git clone "$CIRCLE_REPOSITORY_URL" .
fi
```

## 参考

https://circleci.com/docs/ja/2.0/configuration-reference/
> この例の checkout ステップは、プロジェクトのソース コードをジョブの working_directory にチェックアウトします。

https://circleci.com/docs/ja/2.0/configuration-reference/#jobs
>  working_directory 
 ステップを実行するディレクトリ。 デフォルトは ~/project となります (この project は特定のプロジェクトの名前ではなく、リテラル文字列)。 ジョブ内で実行するプロセスでは、$CIRCLE_WORKING_DIRECTORY 環境変数を介してこのディレクトリを参照できます。 メモ: YAML 設定ファイルに記述したパスは展開されません。



