### PR TITLE
add google drive

### DIFF
--- a/googledrive/command_result_upload.go
+++ b/googledrive/command_result_upload.go
@@ -1,0 +1,74 @@
+// +build integration
+
+package googledrive
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+
+	"google.golang.org/api/drive/v3"
+)
+
+// CommandResultUpload is struct to command result upload.
+type CommandResultUpload struct {
+	srv      *drive.Service
+	command  string
+	fileInfo FileInfo
+}
+
+// Exec executes command and upload result to googledrive.
+func (c CommandResultUpload) Exec(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stdout, stderr, cmdWait, err := commandContextExec(ctx, c.command)
+	if err != nil {
+		return fmt.Errorf("failed to commandExec: %v", err)
+	}
+	go func() {
+		scan(stderr)
+	}()
+
+	if err := UploadFile(c.srv, stdout, c.fileInfo); err != nil {
+		// if err := UploadFile(c.srv, stdout, c.fname, c.fdescription, c.mimeType, c.parentID, c.gzipFlg); err != nil {
+		cancel()
+		return fmt.Errorf("failed to UploadFile: %v", err)
+	}
+	if err := cmdWait(); err != nil {
+		return fmt.Errorf("failed to exec Command Wait: %v", err)
+	}
+	return nil
+}
+
+func commandContextExec(ctx context.Context, command string) (io.ReadCloser, io.ReadCloser, func() error, error) {
+	cmd := exec.CommandContext(ctx, "bash", "-c", command)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to exec Command StdoutPipe: %v", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to exec Command StderrPipe: %v", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to exec Command Start: %v", err)
+	}
+
+	// goroutineでWaitをしたら以下のエラーが出たのでWaitする関数を返してupload後に実行させることにした
+	// An error occurred: read |0: file already closed
+	return stdout, stderr, func() error {
+		return cmd.Wait()
+	}, nil
+}
+
+func scan(s io.ReadCloser) {
+	scanner := bufio.NewScanner(s)
+	for scanner.Scan() {
+		l := scanner.Text()
+		log.Println(l)
+	}
+}

--- a/googledrive/googledrive.go
+++ b/googledrive/googledrive.go
@@ -1,0 +1,337 @@
+package googledrive
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+
+	"golang.org/x/net/context"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+)
+
+// GetDriveService gets drive client.
+func GetDriveService(ctx context.Context, driveCredential string) (*drive.Service, error) {
+
+	srv, err := drive.NewService(ctx, option.WithCredentialsFile(driveCredential), option.WithScopes(drive.DriveScope))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve Drives Client: %v", err)
+	}
+	return srv, nil
+}
+
+// GetFolderIDOrCreate returns folder id. If folder is not yet, create it and returns folder id.
+func GetFolderIDOrCreate(srv *drive.Service, folderName, permissionTargetGmail string) (string, error) {
+	id, err := getFolderID(srv, folderName)
+	if err != nil {
+		return "", fmt.Errorf("failed to getFolderID: %v", err)
+	}
+	if id != "" {
+		log.Printf("folder already exists. %s(%s)", folderName, id)
+		return id, nil
+	}
+
+	// folderがまだない場合は作る
+	log.Println(folderName, "folder not exists yet, create it")
+	id, err = createFolder(srv, folderName, permissionTargetGmail)
+	if err != nil {
+		return "", fmt.Errorf("failed to createFolder: %v", err)
+	}
+	return id, nil
+}
+
+// getFolderID returns folder id.
+func getFolderID(srv *drive.Service, folderName string) (string, error) {
+	return getObjectID(srv, folderName, "application/vnd.google-apps.folder", "folder")
+}
+
+// getFileID returns file id.
+func getFileID(srv *drive.Service, fileName, mimeType string) (string, error) {
+	return getObjectID(srv, fileName, mimeType, "file")
+}
+
+func getObjectID(srv *drive.Service, name, mimeType, objectType string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("%s name is empty", objectType)
+	}
+
+	// Qの指定対象はここで調べる：https://developers.google.com/drive/api/v3/reference/files
+	// 検索方法参考: https://developers.google.com/drive/api/v3/search-files
+	q := fmt.Sprintf(`name="%s" and mimeType="%s"`, name, mimeType)
+
+	r, err := srv.Files.List().
+		// Fields("nextPageToken, files(id, name)").
+		Q(q).
+		//MaxResults(1).
+		Do()
+	if err != nil {
+		log.Printf("failed to List %ss: %v. target: %s. mimeType: %s", err, objectType, name, mimeType)
+		return "", nil // まだ作られていない場合は普通にあり得るのでエラーは返さない
+	}
+	if len(r.Files) == 0 { // まだ作られていない場合は普通にあり得るのでエラーは返さない
+		log.Printf("got no %ss. target: %s. mimeType: %s", objectType, name, mimeType)
+		return "", nil
+	}
+	if len(r.Files) >= 2 { // 2つ以上見つかった場合はWARN
+		log.Printf("WARN: there are duplicate %ss. target: %s. mimeType: %s", objectType, name, mimeType)
+		for i, f := range r.Files {
+			log.Printf("  [%d] name: %s, id: %s", i+1, f.Name, f.Id)
+		}
+		log.Println("  -> chose", r.Files[0].Id)
+	}
+	return r.Files[0].Id, nil
+}
+
+func createFolder(srv *drive.Service, folderName, permissionTargetGmail string) (string, error) {
+	f := &drive.File{
+		Name:     folderName,
+		MimeType: "application/vnd.google-apps.folder",
+	}
+	res, err := srv.Files.
+		Create(f).
+		ProgressUpdater(func(now, size int64) { fmt.Printf("%d, %d\r", now, size) }).
+		Do()
+	if err != nil {
+		return "", fmt.Errorf("failed to create: %v", err)
+	}
+	folderID := res.Id
+	log.Println("created folder:", res.Name, res.Id)
+
+	if permissionTargetGmail != "" {
+		// service accountで作成したファイル、フォルダは通常のユーザには見られない
+		// 以下でパーミッションを変更して所有者を自分に変更する
+		// 参考：https://teratail.com/questions/152937
+		permission := &drive.Permission{
+			EmailAddress: permissionTargetGmail, // folderの共有先のGmail（自分のGmailアドレス）
+			Role:         "owner",
+			Type:         "user",
+		}
+		if _, err := srv.Permissions.Create(folderID, permission).TransferOwnership(true).Do(); err != nil {
+			return "", fmt.Errorf("failed to create permission: %v", err)
+		}
+		log.Println("created folder permission:", res.Name, res.Id, permissionTargetGmail)
+	}
+	return folderID, nil
+}
+
+// FileInfo is struct for upload file.
+type FileInfo struct {
+	Name        string
+	Description string
+	// MimeType: text/plain or application/gzip
+	// ref: https://developer.mozilla.org/ja/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+	// google drive mimeType: https://developers.google.com/drive/api/v3/mime-types
+	// mimeType official: http://www.iana.org/assignments/media-types/media-types.xhtml
+	MimeType  string
+	ParentID  string
+	Overwrite bool // 上書きするかのフラグ
+}
+
+// UploadFile uploads file.
+func UploadFile(srv *drive.Service, content io.Reader, fi FileInfo) error {
+	log.Printf("upload target name: %s, mimeType: %s, parentID: %v, overwrite: %v", fi.Name, fi.MimeType, fi.ParentID, fi.Overwrite)
+	if fi.MimeType == "application/gzip" { // これをすると一時的にメモリにcontentが全部載るので、リソースを食うはず
+		log.Println("mimeType is application/gzip. try to gzip")
+		d, err := gzipData(ioReaderToBytes(content))
+		if err != nil {
+			return fmt.Errorf("failed to gzip: %v", err)
+		}
+		// []byte からio.Readerに戻す
+		content = bytes.NewReader(d)
+	} else if fi.MimeType != "text/plain" {
+		return fmt.Errorf("invalid mimeType: %s. you can use text/plain or application/gzip", fi.MimeType)
+	}
+
+	// ref. https://pkg.go.dev/google.golang.org/api/googleapi?tab=doc#ProgressUpdater
+	progressUpdater := func(current, total int64) { log.Printf("%dB / %dB total\n", current, total) }
+
+	var uploadedID string
+	log.Println("start upload")
+	if fi.Overwrite {
+		fileID, err := getFileID(srv, fi.Name, fi.MimeType)
+		if err != nil {
+			return fmt.Errorf("failed to getFileID, target file: %s. mimeType: %s, err: %v", fi.Name, fi.MimeType, err)
+		}
+		if fileID == "" {
+			return fmt.Errorf("no target file: %s. mimeType: %s. fileID is empty", fi.Name, fi.MimeType)
+		}
+		log.Println("overwrite target:", fi.Name, fileID)
+		f := &drive.File{Name: fi.Name, Description: fi.Description, MimeType: fi.MimeType}
+		// Updateメソッドを使うときはAddParentsでparentsを指定しないと以下のエラーになる
+		// googleapi: Error 403: The parents field is not directly writable in update requests. Use the addParents and removeParents parameters instead., fieldNotWritable
+		// ref: https://github.com/googleapis/google-api-go-client/blob/a87a0974131ca1aa879e0dd1d89726d577540c28/drive/v3/drive-gen.go#L1335-L1341
+		// > Update requests must use the addParents and
+		// > removeParents parameters to modify the parents list.
+		r, err := srv.Files.Update(fileID, f).
+			AddParents(fi.ParentID).
+			Media(content).
+			ProgressUpdater(progressUpdater).
+			Do()
+		if err != nil {
+			return fmt.Errorf("error occurred in upload(update): %v", err)
+		}
+		uploadedID = r.Id
+	} else {
+		f := &drive.File{Name: fi.Name, Description: fi.Description, MimeType: fi.MimeType}
+		if fi.ParentID != "" {
+			f.Parents = []string{fi.ParentID}
+		}
+		r, err := srv.Files.Create(f).
+			Media(content).
+			ProgressUpdater(progressUpdater).
+			Do()
+		if err != nil {
+			return fmt.Errorf("error occurred in upload(create): %v", err)
+		}
+		uploadedID = r.Id
+	}
+
+	log.Printf("upload Done. ID : %s\n", uploadedID)
+	return nil
+}
+
+// DownloadFile uploads file.
+func DownloadFile(srv *drive.Service, fileID, mimeType string) (string, error) {
+	log.Println("start download")
+
+	// v2のしかGoのサンプルがないのでなんとなくで作った
+	// https://developers.google.com/drive/api/v2/reference/files/get
+
+	// こういうDownload方法もある：https://stackoverflow.com/questions/18177419/download-public-file-from-google-drive-golang
+	resp, err := srv.Files.
+		Get(fileID).
+		Download()
+	if err != nil {
+		return "", fmt.Errorf("error occurred in download: %v. fileID: %s", err, fileID)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		// resp.Bodyを読み込んで捨てる
+		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			return "", fmt.Errorf("failed to ioutil.Discard: %v", err)
+		}
+		return "", fmt.Errorf("status error: %s", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %v", err)
+	}
+	log.Printf("download Done. ID : %s\n", fileID)
+
+	if mimeType == "application/gzip" {
+		log.Println("mimeType is application/gzip. try to gunzip")
+		d, err := gunzipData(body)
+		if err != nil {
+			return "", fmt.Errorf("failed to gunzip: %v", err)
+		}
+		return string(d), nil
+	} else if mimeType != "text/plain" {
+		return "", fmt.Errorf("invalid mimeType: %s. you can use text/plain or application/gzip", mimeType)
+	}
+
+	return string(body), nil
+}
+
+func ioReaderToBytes(r io.Reader) []byte {
+	buf := new(bytes.Buffer)
+	io.Copy(buf, r)
+	return buf.Bytes()
+}
+
+func gzipData(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	if _, err := gz.Write(data); err != nil {
+		return nil, fmt.Errorf("failed to gzip Write: %v", err)
+	}
+	if err := gz.Flush(); err != nil {
+		return nil, fmt.Errorf("failed to gzip Flush: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("failed to gzip Close: %v", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+func gunzipData(data []byte) ([]byte, error) {
+	b := bytes.NewBuffer(data)
+
+	var r io.Reader
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create NewReader: %v", err)
+	}
+
+	var res bytes.Buffer
+	_, err = res.ReadFrom(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ReadFrom: %v", err)
+	}
+
+	return res.Bytes(), nil
+}
+
+// PrintList prints all file.
+func PrintList(srv *drive.Service, cond string) error {
+	l, err := List(srv, cond)
+	if err != nil {
+		return fmt.Errorf("failed to List: %v", err)
+	}
+	fmt.Println("Files:")
+	if len(l) == 0 {
+		fmt.Println("No files found.")
+	} else {
+		for _, f := range l {
+			fmt.Printf("%s (%s) parents: %v\n", f.Name, f.Id, f.Parents)
+		}
+	}
+	return nil
+}
+
+// List returns all files which satisfy search condition with all file fields.
+func List(srv *drive.Service, cond string) ([]*drive.File, error) {
+	// 以下のFieldsで指定した項目がFileの中身に返ってくる
+	// Fieldsで指定していない項目については、File.Nameのように参照しようとしても空なので注意
+	// Fieldsの項目の定義：https://developers.google.com/drive/api/v3/reference/files
+	listCall := srv.Files.List().
+		Fields("nextPageToken, files(parents, id, name, kind, size, mimeType, lastModifyingUser, modifiedTime, iconLink, owners, folderColorRgb, shared, webViewLink, webContentLink)")
+
+	// 検索条件がある場合はそれを指定する
+	// 検索例：https://developers.google.com/drive/api/v3/search-files
+	// 検索に使用できる項目：https://developers.google.com/drive/api/v3/ref-search-terms
+	if cond != "" {
+		listCall = listCall.Q(cond)
+	}
+
+	r, err := listCall.
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve files: %v", err)
+	}
+	return r.Files, nil
+}
+
+// Delete deletes all files from google drive.
+func Delete(srv *drive.Service, ids ...string) error {
+	// ref: https://developers.google.com/drive/api/v2/reference/files/delete
+	// v3にはGoのサンプルがなかったけど大体同じだった
+
+	var e string
+	for _, id := range ids {
+		if err := srv.Files.Delete(id).Do(); err != nil {
+			e += fmt.Sprintf("failed to delete file: %v ", err)
+		}
+		log.Printf("delete Done. ID : %s\n", id)
+	}
+	if e != "" { // まとめて最後にエラーとして返す
+		return errors.New(e)
+	}
+	return nil
+}

--- a/googledrive/googledrive_test.go
+++ b/googledrive/googledrive_test.go
@@ -1,0 +1,158 @@
+// +build integration
+
+package googledrive
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGoogleDrive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	driveCredential := mustGetenv(t, "DRIVE_CREDENTIAL")
+	srv, err := GetDriveService(ctx, "../"+driveCredential) // rootディレクトリに置いてあるserviceaccountのjsonを使う
+	if err != nil {
+		t.Fatalf("failed to GetDriveService: %v", err)
+	}
+
+	folderName := "gke-stockprice-googledrive-test-folder"
+	folderID, err := GetFolderIDOrCreate(srv, folderName, "") // permission共有Gmailは空. この場合ユーザにはUIから見ることはできないことに注意
+	if err != nil {
+		t.Fatalf("failed to GetFolderIDOrCreate: %v", err)
+	}
+	t.Log("folderID:", folderID)
+	defer func() { // testがおかしくなってもフォルダを削除して終わる
+		t.Log("delete folder")
+		if err := Delete(srv, folderID); err != nil {
+			t.Fatalf("failed to delete folder: %v", err)
+		}
+	}()
+
+	tests := map[string]struct {
+		mimeType string
+	}{
+		"text_plain": {
+			mimeType: "text/plain",
+		},
+		"application_gzip": {
+			mimeType: "application/gzip",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fileName := "googledrive-test-file"
+			t.Run("upload_download", func(t *testing.T) {
+				fi := FileInfo{
+					Name:        fileName,
+					Description: "this is googledrive test file to test",
+					MimeType:    tc.mimeType,
+					ParentID:    folderID,
+					Overwrite:   false, // 上書きするかのフラグ
+				}
+				content := "this is test"
+				s := strings.NewReader(content)
+				if err := UploadFile(srv, s, fi); err != nil {
+					t.Fatalf("failed to UploadFile: %v", err)
+				}
+
+				fileCondition := fmt.Sprintf("name = '%s' and mimeType = '%s'", fileName, tc.mimeType)
+				uploadedFile, err := List(srv, fileCondition)
+				if err != nil {
+					t.Fatalf("failed to List: %v. search condition: %+v", err, fileCondition)
+				}
+				if len(uploadedFile) == 0 {
+					t.Fatalf("failed to get file. search condition: %+v", fileCondition)
+				}
+				if len(uploadedFile) > 1 { // 2つ以上あったらおかしい
+					for i, f := range uploadedFile {
+						t.Logf("[%d] parents: %s, name: %s, id: %s", i, f.Parents, f.Name, f.Id)
+					}
+					t.Fatalf("there are duplicated files. search condition: %+v", fileCondition)
+				}
+				fileID, mimeType := uploadedFile[0].Id, uploadedFile[0].MimeType
+				if mimeType != tc.mimeType {
+					t.Fatalf("got mimeType: %s, want: %s", mimeType, tc.mimeType)
+				}
+
+				donwloaded, err := DownloadFile(srv, fileID, mimeType)
+				if err != nil {
+					t.Fatalf("failed to DownloadFile: %v", err)
+				}
+				if donwloaded != content {
+					t.Fatalf("downloaded: %s, want: %s", donwloaded, content)
+				}
+				t.Log("file content:", content)
+			})
+			// 以下は上書きのテスト
+			t.Run("upload_download_overwrite", func(t *testing.T) {
+				fi := FileInfo{
+					Name:        fileName,
+					Description: "this is googledrive test file to test",
+					MimeType:    tc.mimeType,
+					ParentID:    folderID,
+					Overwrite:   true, // 上書きする
+				}
+				content2 := "this is test2"
+				s := strings.NewReader(content2)
+				if err := UploadFile(srv, s, fi); err != nil {
+					t.Fatalf("failed to UploadFile: %v", err)
+				}
+
+				fileCondition := fmt.Sprintf("name = '%s' and mimeType = '%s'", fileName, tc.mimeType)
+				uploadedFile, err := List(srv, fileCondition)
+				if err != nil {
+					t.Fatalf("failed to List: %v. search condition: %+v", err, fileCondition)
+				}
+				if len(uploadedFile) == 0 {
+					t.Fatalf("failed to get file. search condition: %+v", fileCondition)
+				}
+				if len(uploadedFile) > 1 { // 2つ以上あったらおかしい
+					for i, f := range uploadedFile {
+						t.Logf("[%d] parents: %s, name: %s, id: %s", i, f.Parents, f.Name, f.Id)
+					}
+					t.Fatalf("there are duplicated files. search condition: %+v", fileCondition)
+				}
+				fileID, mimeType := uploadedFile[0].Id, uploadedFile[0].MimeType
+				if mimeType != tc.mimeType {
+					t.Fatalf("got mimeType: %s, want: %s", mimeType, tc.mimeType)
+				}
+
+				donwloaded, err := DownloadFile(srv, fileID, mimeType)
+				if err != nil {
+					t.Fatalf("failed to DownloadFile: %v", err)
+				}
+				if donwloaded != content2 {
+					t.Fatalf("downloaded: %s, want: %s", donwloaded, content2)
+				}
+				t.Log("file content:", content2)
+
+				if err := Delete(srv, fileID); err != nil {
+					t.Fatalf("failed to delete file: %v", err)
+					afterFiles, err := List(srv, fmt.Sprintf("name = '%s'", fileName))
+					if err != nil {
+						t.Fatalf("failed to List: %v", err)
+					}
+					if len(afterFiles) > 0 { // ファイルが残っていたらおかしい
+						for i, f := range afterFiles {
+							t.Logf("[%d] parents: %s, name: %s, id: %s", i, f.Parents, f.Name, f.Id)
+						}
+						t.Fatalf("file stil exist")
+					}
+				}
+			})
+		})
+	}
+}
+
+func mustGetenv(t *testing.T, k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		t.Fatalf("%s environment variable not set", k)
+	}
+	return v
+}


### PR DESCRIPTION
Google driveを使えるようにする

## 参考
#### 公式
クイックスタート
[Go Quickstart  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/quickstart/go)

公式の認証
[Authenticate your users  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/about-auth)

[Using OAuth 2.0 for Server to Server Applications](https://developers.google.com/identity/protocols/oauth2/service-account)
- JWT and OAuth
- NewではなくNewServiceを使ったやり方でしか関係ない?

API Reference
[API Reference  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/reference)

create(upload)
[Files: create  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/reference/files/create)

update
[Files: update  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/reference/files/update)

list
[Files: list  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/reference/files/list)

get(download)
[Files: get  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/reference/files/get)

[Search for files and folders  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/search-files#java)
[Search query terms  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/ref-search-terms)

FileのField
[Files  \|  Google Drive API  |  Google Developers](https://developers.google.com/drive/api/v3/reference/files)

#### Go Doc
[drive package · pkg.go.dev](https://pkg.go.dev/google.golang.org/api@v0.29.0/drive/v3?tab=doc#FilesCreateCall.ResumableMedia)
[googleapi package · pkg.go.dev](https://pkg.go.dev/google.golang.org/api@v0.29.0/googleapi?tab=doc#MediaOption)

#### GoogleDriveAPI
[google-api-go-client/drive-gen.go at a87a0974131ca1aa879e0dd1d89726d577540c28 · googleapis/google-api-go-client · GitHub](https://github.com/googleapis/google-api-go-client/blob/a87a0974131ca1aa879e0dd1d89726d577540c28/drive/v3/drive-gen.go#L1335-L1341)

#### Googledrive各種使用例

[Practical Golang: Using Google Drive and Calendar \| Jacob Martin](https://jacobmartins.com/2016/03/08/practical-golang-using-google-drive-and-calendar/)
[Google Drive上のファイルをOCRする - Qiita](https://qiita.com/shin1ogawa/items/559ec58f6d7840721e5a)
[Google Drive API v3で特定のフォルダ以下のファイルを再帰的に取得する · Konboi Note](https://blog.konboi.com/post/2018/05/08/173903/)
[Golang to upload file to google drive with progress bar using Google API · GitHub](https://gist.github.com/TheGU/e6d0ae13f2fa83f3bd8d)
[Google Drive Web APIを使う(node編) - Qiita](https://qiita.com/kompiro/items/8e4c4d79cbbb5a3c95f6)
[Go言語でGoogle Drive APIとGmail APIを使う方法メモ - Qiita](https://qiita.com/KMim/items/f6e14cdaed8ad1907930)
[Upload files in Google Drive with Golang and Google Drive API](https://medium.com/@devtud/upload-files-in-google-drive-with-golang-and-google-drive-api-d686fb62f884)

