### PR TITLE
gcloud auth activate-service-account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,22 +291,17 @@ jobs:
             curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
             ./kustomize version
       - run:
+          name: Activate Service Account
+          command: |
+            echo $GCLOUD_SERVICE_KEY | base64 -di > gke-stockprice-serviceaccount.json
+            gcloud auth activate-service-account --key-file gke-stockprice-serviceaccount.json
+      - run:
           name: Setup GKE Cluster Infomation
           command: |
             gcloud config set project $PROJECT_NAME
-      #      gcloud config set compute/zone ${COMPUTE_ZONE}
-      # - run:
-      #     name: Activate Service Account
-      #     command: |
-      #       echo $GCLOUD_SERVICE_KEY | base64 -di > gke-stockprice-serviceaccount.json
-      #       gcloud auth activate-service-account --key-file gke-stockprice-serviceaccount.json
-      #       - run:
-      #         name: Setup GKE Cluster Infomation
-      #         command: |
-      #           gcloud config set project $PROJECT_NAME
-      #           gcloud config set container/cluster $CLUSTER_NAME
-      #           gcloud config set compute/zone ${COMPUTE_ZONE}
-      #           gcloud container clusters get-credentials $CLUSTER_NAME
+            gcloud config set compute/zone ${COMPUTE_ZONE}
+      # gcloud config set container/cluster $CLUSTER_NAME
+      # gcloud container clusters get-credentials $CLUSTER_NAME
       - run:
           name: Create config & secret
           command: |


### PR DESCRIPTION
https://github.com/ludwig125/gke-stockprice/pull/48
で
gcloud auth activate-service-account
をし忘れていたので
`"ERROR: (gcloud.container.clusters.list) You do not currently have an active account selected."` というエラーが出た