### PR TITLE
Spreadsheetで1000行を超える空のセルを存在させないようにする

### DIFF
--- a/daily.go
+++ b/daily.go
@@ -69,6 +69,7 @@ func (d daily) exec(ctx context.Context, codes []string) error {
 			var e error
 			failedCodes, e = sp.saveStockPrice(ctx, fcodes, now())                                    // ここで改めてfailedCodesが上書きされる
 			st.InsertStatus(fmt.Sprintf("saveStockPrice_retry%d", retryCnt), now(), now().Sub(start)) // now().Sub(start)で所要時間も入れておく
+			log.Printf("retry: %d. updated failedCodes: %v, error: %v", retryCnt, failedCodes, e)
 			return e
 		}); err != nil {
 			// retry 時のエラーはログに出すだけにしておく

--- a/sheet/sheet_test.go
+++ b/sheet/sheet_test.go
@@ -33,7 +33,7 @@ func TestSheet(t *testing.T) {
 	if err := ts.Update(testdata); err != nil {
 		t.Error(err)
 	}
-	// testdata２つ分追加で書き込む
+	// 同じtestdataを３つ分書き込む
 	if err := ts.Insert(append(testdata, testdata...)); err != nil {
 		t.Error(err)
 	}
@@ -54,7 +54,7 @@ func TestSheet(t *testing.T) {
 	}
 
 	// データを削除する
-	if err := ts.Update([][]string{}); err != nil {
+	if err := ts.Clear(); err != nil {
 		t.Error(err)
 	}
 	got, err = ts.Read()
@@ -75,81 +75,3 @@ func mustGetenv(t *testing.T, k string) string {
 	}
 	return v
 }
-
-// func TestRead(t *testing.T) {
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	defer cancel()
-
-// 	sheetCredential := mustGetenv("CREDENTIAL_FILEPATH")
-// 	// spreadsheetのserviceを取得
-// 	srv, err := GetSheetClient(ctx, sheetCredential)
-// 	if err != nil {
-// 		t.Fatalf("failed to get sheet service. err: %v", err)
-// 	}
-// 	log.Println("succeeded to get sheet service")
-
-// 	testSheetID := mustGetenv("INTEGRATION_TEST_SHEETID")
-// 	t.Run("testSheet", func(t *testing.T) {
-// 		testHolidaySheet(t, srv, testSheetID)
-// 		testCodeSheet(t, srv, testSheetID)
-// 	})
-// }
-
-// func testHolidaySheet(t *testing.T, srv *sheets.Service, sid string) {
-// 	si := SpreadSheet{Service: srv,
-// 		SpreadsheetID: sid,
-// 		ReadRange:     "holiday",
-// 	}
-// 	resp, err := si.Read()
-// 	if err != nil {
-// 		t.Fatalf("failed to ReadSheet: %v", err)
-// 	}
-// 	t.Log(resp[0][0])
-// 	for _, v := range resp {
-// 		t.Log(v[0])
-// 	}
-// }
-
-// func testCodeSheet(t *testing.T, srv *sheets.Service, sid string) {
-// 	si := SpreadSheet{
-// 		Service:       srv,
-// 		SpreadsheetID: sid,
-// 		ReadRange:     "tse-first",
-// 	}
-// 	resp, err := si.Read()
-// 	if err != nil {
-// 		t.Fatalf("failed to ReadSheet: %v", err)
-// 	}
-// 	log.Println(resp[0][0])
-// 	t.Log("res", resp[0][0])
-// 	os.Exit(0)
-// 	for _, v := range resp {
-// 		t.Log(v[0])
-// 	}
-// }
-
-// func TestUpdate(t *testing.T) {
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	defer cancel()
-
-// 	sheetCredential := mustGetenv("CREDENTIAL_FILEPATH")
-// 	// spreadsheetのserviceを取得
-// 	srv, err := GetSheetClient(ctx, sheetCredential)
-// 	if err != nil {
-// 		t.Fatalf("failed to get sheet service. err: %v", err)
-// 	}
-// 	log.Println("succeeded to get sheet service")
-// 	sid := mustGetenv("INTEGRATION_TEST_SHEETID")
-
-// 	si := SpreadSheet{
-// 		Service:       srv,
-// 		SpreadsheetID: sid,
-// 		ReadRange:     "sample",
-// 	}
-// 	data := [][]string{
-// 		[]string{"a", "b"},
-// 		[]string{"c", "d"},
-// 	}
-
-// 	si.Update(data)
-// }


### PR DESCRIPTION
https://github.com/ludwig125/gke-stockprice/pull/53
ででた　
`This action would increase the number of cells in the workbook above the limit of 5000000 cells., badRequest` の根本的解決。

値のClearと合わせて、1000行を超える空のセルが存在する場合はDeleteDimensionRequestを使って削除する

DeleteDimensionRequestを使うためにはSheetIDというSpreadsheetIDとは別のIDが必要なのでその取得をする。
同時にそのリクエストで、現在の行数と現在の列数が取得できた。

## 参考：

#### 同様の事例
https://stackoverflow.com/questions/61590412/deleting-empty-cells-from-google-spreadsheet-programatically-to-avoid-5000000-ce
https://stackoverflow.com/questions/46696168/google-sheets-api-addprotectedrange-error-no-grid-with-id-0
https://stackoverflow.com/questions/48574902/how-to-delete-row-from-google-sheets-using-api-v4-in-php?rq=1
https://stackoverflow.com/questions/39159535/i-want-to-delete-row-in-googlesheet-using-googlesheet-api-v4
https://gist.github.com/bati11/b2ba535f74c7bcb723a2ee46585814d8#file-spread_sheets_api_sample-go-L68

#### 公式ドキュメント
https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchUpdate
https://developers.google.com/sheets/api/samples/rowcolumn#delete_rows_or_columns
https://developers.google.com/sheets/api/samples/sheet#determine_sheet_id_and_other_properties
https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get